### PR TITLE
Simplified command-line handling of source files

### DIFF
--- a/README.org
+++ b/README.org
@@ -172,12 +172,12 @@ Clog supports multiple running modes, which represent a trade-off between speed 
 ** Internal evaluation
 Uses the internal semi-naive evaluator and it is reasonably fast when the number of tuples is small (< 1 million).
 #+BEGIN_SRC
-java -jar compiler.jar --eval metadl program.mdl -F fact_dir -D output_dir
+java -jar compiler.jar --eval metadl program.mdl -F fact_dir -D output_dir -S program_to_analyse_dir
 #+END_SRC
 ** Internal parallel evaluation
 Depending on the shape of the strata dependency is graph, the parallel evaluator may speed things up.
 #+BEGIN_SRC
-java -jar compiler.jar --eval metadl-par program.mdl -F fact_dir -D output_dir
+java -jar compiler.jar --eval metadl-par program.mdl -F fact_dir -D output_dir -S program_to_analyse_dir
 #+END_SRC
 
 * Language description

--- a/src/java/lang/CmdLineOpts.java
+++ b/src/java/lang/CmdLineOpts.java
@@ -275,12 +275,8 @@ public class CmdLineOpts {
 				} else {
 					ret.srcs = new TreeMap<>();
 					for (String f : cmd.getOptionValue("S").split(":")) {
-						String[] fileAndMod = f.split(",");
-						if (fileAndMod.length != 2) {
-							throw new RuntimeException("Error parsing the -sources [-S] argument.");
-						} else {
-							ret.srcs.put(fileAndMod[0], fileAndMod[1]);
-						}
+						// [CR] I don't think we use this yet
+						ret.srcs.put(f, "A");
 					}
 				}
 			} else {

--- a/src/test/lang/CEvaluationTest.java
+++ b/src/test/lang/CEvaluationTest.java
@@ -49,6 +49,7 @@ public class CEvaluationTest {
                                 "--extra-arg -I" + includeDir.toAbsolutePath());
     } catch (Exception e) {
       System.err.println("Unexpected exception " + e);
+      e.printStackTrace();
       fail();
     }
   }

--- a/src/test/lang/Util.java
+++ b/src/test/lang/Util.java
@@ -229,7 +229,7 @@ public final class Util {
                                           String cmd,
                                           String Xclang) throws Exception {
 
-    String sources = analyzedFiles.stream().map(f -> f.getPath() + ",A").collect(Collectors.joining(":"));
+    String sources = analyzedFiles.stream().map(f -> f.getPath()).collect(Collectors.joining(":"));
 
     String desc = cmd
       + " -L " + lang


### PR DESCRIPTION
Previously, the mandatory `-S` parameter took a key-value pair list, though the "value" part wasn't used anywhere in the code (as far as I could see).
This change allows specifying
```-S foo.c:bar.c```
instead of
```-S foo.c,A:bar.c:A```
to analyse the two source files `foo.c` and `bar.c`.